### PR TITLE
remove logger_facade as it does not support rails new versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,52 +1,30 @@
 PATH
   remote: .
   specs:
-    zss (0.3.5)
+    zss (0.3.7)
       activesupport (>= 4.2)
       daemons (~> 1.1)
       em-zeromq (~> 0.5)
       ffi-rzmq (~> 2.0)
       hashie (~> 3.2)
-      logger_facade (~> 0.4.1)
       msgpack (~> 1.1.0)
       party_foul
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.8)
-      builder
-      multi_json
-    builder (3.2.3)
     bump (0.5.1)
-    celluloid (0.17.3)
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      timers (>= 4.1.1)
-    celluloid-essentials (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.6)
-      timers (>= 4.1.1)
     codeclimate-test-reporter (0.4.6)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
-    concurrent-ruby (1.0.5)
-    daemons (1.2.6)
+    concurrent-ruby (1.1.4)
+    daemons (1.3.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
     em-zeromq (0.5.0)
@@ -62,13 +40,8 @@ GEM
     ffi-rzmq-core (1.0.6)
       ffi
     hashie (3.6.0)
-    hitimes (1.3.0)
-    i18n (1.1.1)
+    i18n (1.4.0)
       concurrent-ruby (~> 1.0)
-    logger_facade (0.4.1)
-      airbrake (~> 4.0)
-      hashie (~> 3.2)
-      sucker_punch (~> 1.1)
     method_source (0.8.2)
     minitest (5.11.3)
     msgpack (1.1.0)
@@ -105,11 +78,7 @@ GEM
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
     slop (3.6.0)
-    sucker_punch (1.6.0)
-      celluloid (~> 0.17.2)
     thread_safe (0.3.6)
-    timers (4.1.2)
-      hitimes
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
@@ -127,4 +96,4 @@ DEPENDENCIES
   zss!
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/lib/zss.rb
+++ b/lib/zss.rb
@@ -3,7 +3,6 @@ require 'active_support/string_inquirer'
 require 'active_support/core_ext/object'
 require 'active_support/core_ext/hash/indifferent_access'
 
-require 'logger_facade'
 
 require_relative 'zss/version'
 require_relative 'zss/environment'

--- a/lib/zss/client.rb
+++ b/lib/zss/client.rb
@@ -4,7 +4,6 @@ require_relative 'socket'
 module ZSS
   class Client
 
-    include LoggerFacade::Loggable
 
     attr_reader :sid, :frontend, :identity, :timeout
 

--- a/lib/zss/service.rb
+++ b/lib/zss/service.rb
@@ -6,7 +6,6 @@ require_relative 'message/smi'
 module ZSS
   class Service
 
-    include LoggerFacade::Loggable
 
     attr_reader :sid, :heartbeat, :backend, :identity
 

--- a/lib/zss/socket.rb
+++ b/lib/zss/socket.rb
@@ -4,7 +4,6 @@ require 'timeout'
 module ZSS
   class Socket
 
-    include LoggerFacade::Loggable
 
     class Error        < StandardError; end
     class TimeoutError < Socket::Error; end

--- a/zss.gemspec
+++ b/zss.gemspec
@@ -37,5 +37,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'daemons', '~> 1.1'
   spec.add_dependency 'em-zeromq', '~> 0.5'
   spec.add_dependency 'party_foul'
-  spec.add_dependency 'logger_facade', '~> 0.4.1'
 end


### PR DESCRIPTION
Fix for [rails upgrade](https://github.com/ISEngineering/iq_scan/issues/277)